### PR TITLE
Restore compatibility with legacy LIFF config keys

### DIFF
--- a/public/diagnosis.html
+++ b/public/diagnosis.html
@@ -56,8 +56,10 @@
   <!-- 任意: 設定チェック -->
   <script defer>
     window.addEventListener('DOMContentLoaded', () => {
-      if (!window.ENV || !window.ENV.LIFF?.DIAG || !window.ENV.API_BASE) {
-        console.warn('config.js の設定不足: ENV.LIFF.DIAG / ENV.API_BASE');
+      const env = window.ENV || {};
+      const hasLiffId = !!(env?.LIFF?.DIAG || env?.LIFF_ID);
+      if (!hasLiffId || !env?.API_BASE) {
+        console.warn('config.js の設定不足: ENV.LIFF.DIAG または ENV.LIFF_ID / ENV.API_BASE');
       }
     });
   </script>

--- a/public/index.html
+++ b/public/index.html
@@ -58,8 +58,10 @@
   <!-- （任意）config 未ロード時の簡易警告 -->
   <script defer>
     window.addEventListener('DOMContentLoaded', () => {
-      if (!window.ENV || !window.ENV.LIFF?.LOG || !window.ENV.API_BASE) {
-        console.warn('config.js の設定不足: ENV.LIFF.LOG / ENV.API_BASE');
+      const env = window.ENV || {};
+      const hasLiffId = !!(env?.LIFF?.LOG || env?.LIFF_ID);
+      if (!hasLiffId || !env?.API_BASE) {
+        console.warn('config.js の設定不足: ENV.LIFF.LOG または ENV.LIFF_ID / ENV.API_BASE');
       }
     });
   </script>

--- a/public/login.html
+++ b/public/login.html
@@ -66,8 +66,10 @@
   <!-- 任意: 設定チェック -->
   <script defer>
     window.addEventListener('DOMContentLoaded', () => {
-      if (!window.ENV || !window.ENV.LIFF?.LOGIN) {
-        console.warn('config.js の設定不足: ENV.LIFF.LOGIN');
+      const env = window.ENV || {};
+      const hasLiffId = !!(env?.LIFF?.LOGIN || env?.LIFF_ID);
+      if (!hasLiffId) {
+        console.warn('config.js の設定不足: ENV.LIFF.LOGIN または ENV.LIFF_ID');
       }
     });
   </script>

--- a/public/login.js
+++ b/public/login.js
@@ -1,7 +1,18 @@
 // public/login.js
-const LIFF_ID = window.ENV.LIFF_ID;
+const env = window.ENV || {};
+const LIFF_ID = env?.LIFF?.LOGIN || env?.LIFF_ID;
 
 document.addEventListener("DOMContentLoaded", async () => {
+  if (!LIFF_ID) {
+    console.error("config.js の設定が不足しています (ENV.LIFF.LOGIN または ENV.LIFF_ID)");
+    const errorMessage = document.getElementById("errorMessage");
+    if (errorMessage) {
+      errorMessage.textContent = "設定が不足しています。管理者に連絡してください。";
+      errorMessage.style.display = "block";
+    }
+    return;
+  }
+
   const loginBtn = document.getElementById("loginButton");
   const loadingBtn = document.getElementById("loadingBtn");
   const errorMessage = document.getElementById("errorMessage");

--- a/public/main-diagnosis.js
+++ b/public/main-diagnosis.js
@@ -1,6 +1,11 @@
 // public/main-diagnosis.js
-const LIFF_ID = window.ENV.LIFF_ID;
-const API_BASE = window.ENV.API_BASE;
+const env = window.ENV || {};
+const LIFF_ID = env?.LIFF?.DIAG || env?.LIFF_ID;
+const API_BASE = env?.API_BASE;
+
+if (!LIFF_ID || !API_BASE) {
+  console.error("config.js の設定が不足しています (ENV.LIFF.DIAG または ENV.LIFF_ID / ENV.API_BASE)");
+}
 
 const typeData = {
   SENSE: { emoji: '🎨', name: 'センステイスター', tagline: '感性で味わう、アートな一杯。' },
@@ -44,6 +49,11 @@ function renderCards(container, types, beanMap) {
 }
 
 async function renderResults() {
+  if (!LIFF_ID || !API_BASE) {
+    alert("設定が不足しています。管理者に連絡してください。");
+    return;
+  }
+
   const container = document.getElementById("resultsContainer");
   container.innerHTML = '<div class="body">読み込み中...</div>';
 

--- a/public/main-result.js
+++ b/public/main-result.js
@@ -1,9 +1,10 @@
 // public/main-result.js
-const LIFF_ID = window.ENV?.LIFF?.DIAG;   // 診断用 LIFF
-const API_BASE = window.ENV?.API_BASE;    // Functions のベースURL
+const env = window.ENV || {};
+const LIFF_ID = env?.LIFF?.DIAG || env?.LIFF_ID;   // 診断用 LIFF
+const API_BASE = env?.API_BASE;    // Functions のベースURL
 
 if (!LIFF_ID || !API_BASE) {
-  console.error("config.js の設定が不足しています");
+  console.error("config.js の設定が不足しています (ENV.LIFF.DIAG または ENV.LIFF_ID / ENV.API_BASE)");
   alert("設定が不足しています。管理者に連絡してください。");
 }
 

--- a/public/main.js
+++ b/public/main.js
@@ -1,6 +1,11 @@
 // public/main.js
-const LIFF_ID = window.ENV.LIFF_ID;
-const API_BASE = window.ENV.API_BASE;
+const env = window.ENV || {};
+const LIFF_ID = env?.LIFF?.LOG || env?.LIFF_ID;
+const API_BASE = env?.API_BASE;
+
+if (!LIFF_ID || !API_BASE) {
+  console.error("config.js の設定が不足しています (ENV.LIFF.LOG または ENV.LIFF_ID / ENV.API_BASE)");
+}
 
 async function ensureLogin() {
   await liff.init({ liffId: LIFF_ID });
@@ -16,6 +21,11 @@ function setLoading(btn, on) {
 }
 
 window.onload = async () => {
+  if (!LIFF_ID || !API_BASE) {
+    alert("設定が不足しています。管理者に連絡してください。");
+    return;
+  }
+
   try {
     await ensureLogin();
     const idToken = liff.getIDToken();

--- a/public/profile.html
+++ b/public/profile.html
@@ -61,8 +61,10 @@
   <!-- 任意: 設定チェック -->
   <script defer>
     window.addEventListener('DOMContentLoaded', () => {
-      if (!window.ENV || !window.ENV.LIFF?.DIAG) {
-        console.warn('config.js の設定不足: ENV.LIFF.DIAG を設定してください');
+      const env = window.ENV || {};
+      const hasLiffId = !!(env?.LIFF?.DIAG || env?.LIFF_ID);
+      if (!hasLiffId) {
+        console.warn('config.js の設定不足: ENV.LIFF.DIAG または ENV.LIFF_ID を設定してください');
       }
     });
   </script>

--- a/public/profile.js
+++ b/public/profile.js
@@ -1,6 +1,7 @@
 // public/profile.js
 // 診断/結果と同じ LIFF（アプリ内ページなので DIAG を利用）
-const LIFF_ID = window.ENV?.LIFF?.DIAG;
+const env = window.ENV || {};
+const LIFF_ID = env?.LIFF?.DIAG || env?.LIFF_ID;
 
 async function ensureLogin() {
   await liff.init({ liffId: LIFF_ID });

--- a/public/result.html
+++ b/public/result.html
@@ -36,8 +36,10 @@
   <!-- 任意: 設定チェック -->
   <script defer>
     window.addEventListener('DOMContentLoaded', () => {
-      if (!window.ENV || !window.ENV.LIFF?.DIAG || !window.ENV.API_BASE) {
-        console.warn('config.js の設定不足: ENV.LIFF.DIAG / ENV.API_BASE');
+      const env = window.ENV || {};
+      const hasLiffId = !!(env?.LIFF?.DIAG || env?.LIFF_ID);
+      if (!hasLiffId || !env?.API_BASE) {
+        console.warn('config.js の設定不足: ENV.LIFF.DIAG または ENV.LIFF_ID / ENV.API_BASE');
       }
     });
   </script>


### PR DESCRIPTION
## Summary
- allow each LIFF-enabled page to fall back to the legacy ENV.LIFF_ID when a scoped ID is not provided
- update inline configuration warnings to reflect the broader set of acceptable keys so valid setups do not log false errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1029d8a6c8322a958b8a0e42ff3d0